### PR TITLE
Fetch only open issues/PRs by default

### DIFF
--- a/lua/blink-cmp-git/default/github.lua
+++ b/lua/blink-cmp-git/default/github.lua
@@ -148,13 +148,13 @@ local function default_github_pr_issue_mention_get_command_args(command, token, 
         table.insert(args, '-f')
         table.insert(args, 'https://api.github.com/repos/' .. utils.get_repo_owner_and_repo() .. '/' ..
             type_name ..
-            ((type_name == 'issues' or type_name == 'pulls') and '?state=all' or '')
+            ((type_name == 'issues' or type_name == 'pulls') and '?state=open' or '')
         )
     else
         table.insert(args, 1, 'api')
         table.insert(args, 'repos/' .. utils.get_repo_owner_and_repo() .. '/' ..
             type_name ..
-            ((type_name == 'issues' or type_name == 'pulls') and '?state=all' or '')
+            ((type_name == 'issues' or type_name == 'pulls') and '?state=open' or '')
         )
     end
     return args


### PR DESCRIPTION
Please see this PR more as a suggestion than a "fix" really. In my opinion, fetching only open issues/PRs is the more reasonable default, since more often than not, you are only interested in referencing an open issue you are trying to close.