### PR TITLE
fix: escape characters in `magic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ git_centers = {
                 local utils = require('blink-cmp-git.utils')
                 -- Place your enterprise's domain here
                 -- Escape characters (with '%'): ( ) . % + - * ? [ ^ $
-                return enable or utils.get_repo_remote_url():find('enterprise%.do%-main%.com')
+                return enable or utils.get_repo_remote_url():find('enterprise.example.com', 1, true)
             end,
         }
     }

--- a/README.md
+++ b/README.md
@@ -495,7 +495,8 @@ git_centers = {
                     .enable()
                 local utils = require('blink-cmp-git.utils')
                 -- Place your enterprise's domain here
-                return enable or utils.get_repo_remote_url():find('enterprise.example.com')
+                -- Escape characters (with '%'): ( ) . % + - * ? [ ^ $
+                return enable or utils.get_repo_remote_url():find('enterprise%.do%-main%.com')
             end,
         }
     }

--- a/README.md
+++ b/README.md
@@ -495,7 +495,11 @@ git_centers = {
                     .enable()
                 local utils = require('blink-cmp-git.utils')
                 -- Place your enterprise's domain here
-                -- Escape characters (with '%'): ( ) . % + - * ? [ ^ $
+                -- When using `find` without parameters, escape special characters using '%'.
+                -- Escape characters: ( ) . % + - * ? [ ^ $
+                -- `find(pattern, start_index, plain)`
+                -- `start_index = 1` starts searching from the first character.
+                -- `plain = true` ensures an exact match instead of a pattern match.
                 return enable or utils.get_repo_remote_url():find('enterprise.example.com', 1, true)
             end,
         }

--- a/lua/blink-cmp-git/default/common.lua
+++ b/lua/blink-cmp-git/default/common.lua
@@ -24,7 +24,8 @@ function M.default_on_error(return_value, standard_error)
         return true
     end
     for _, ignored_error in pairs(default_ignored_error) do
-        if standard_error:find(ignored_error) then
+        -- always match exact case
+        if standard_error:find(ignored_error, 1, true) then
             return true
         end
     end

--- a/lua/blink-cmp-git/default/github.lua
+++ b/lua/blink-cmp-git/default/github.lua
@@ -9,7 +9,7 @@ local function default_github_enable()
     if utils.truthy(utils.get_repo_owner_and_repo_from_octo()) then
         return true
     end
-    return utils.get_repo_remote_url():find('github.com')
+    return utils.get_repo_remote_url():find('github%.com')
 end
 
 local function default_github_pr_or_issue_get_label(item)

--- a/lua/blink-cmp-git/default/gitlab.lua
+++ b/lua/blink-cmp-git/default/gitlab.lua
@@ -6,7 +6,7 @@ local default_gitlab_enable = function()
         not utils.command_found('glab') and not utils.command_found('curl') then
         return false
     end
-    return utils.get_repo_remote_url():find('gitlab.com')
+    return utils.get_repo_remote_url():find('gitlab%.com')
 end
 
 local function default_gitlab_issue_get_label(item)


### PR DESCRIPTION
# Needs testing!

This PR fixes some probably never occuring edge cases, when someone uses a url that has anything instead of the `.` in between `github` and `com` or `gitlab` and `com`.

## Testing
I don't have a standard `gitlab` account.
Works so far on enterprise `gitlab` and standard `github.com` (on my machine)

## Changes

For the magic search expressions: `gitlab.com` and `github.com` the `.` was escaped with `%`

In another occurence of `find` the searched string was set to `plain`.

Updated the docs for enterprise url (making aware of magic)