### PR TITLE
Better async

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Add the plugin to your packer managers, and make sure it is loaded before `blink
     dependencies = {
         {
             'Kaiser-Yang/blink-cmp-git',
-            dependencies = { 'nvim-lua/plenary.nvim' }
         }
         -- ... other dependencies
     },
@@ -140,10 +139,10 @@ pre-cache when you enter insert mode or other mode you can input
 > For `github` users, if you customize the `get_token`, you should see those below to know
 > which permissions are required:
 >
-> * [commit (for `octo.nvim` users)](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits)
-> * [issue](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues)
-> * [pull-request](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests)
-> * [mention](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-contributors)
+> - [commit (for `octo.nvim` users)](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits)
+> - [issue](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues)
+> - [pull-request](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests)
+> - [mention](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-contributors)
 >
 > For `gitlab` users, see [PAT](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 > to know how to get the token.
@@ -182,7 +181,7 @@ See [default.lua](./lua/blink-cmp-git/default/init.lua).
 Because all features have same fields, I'll use `commit` as an example.
 
 The `blink-cmp-git` will first run command from `get_command` and `get_command_args`. The standout
-of the command will be passed to `separate_output`. So if you want to customize the completion 
+of the command will be passed to `separate_output`. So if you want to customize the completion
 items, you should be aware of what the output of your command looks like.
 
 In most situations, you just need to customize
@@ -260,7 +259,7 @@ git_centers = {
 >
 > `kind_name` is used by those default options:
 >
-> * `kind_icons`
+> - `kind_icons`
 >
 > Therefore, if you customize the `kind_name`, you should customize them too.
 
@@ -306,12 +305,11 @@ Suppose the item in your completion list is like this below:
 ```
 
 | Highlight Group Name              | Description             |
-|-----------------------------------|-------------------------|
+| --------------------------------- | ----------------------- |
 | `BlinkCmpGitKind<kind_name>`      | For ``                 |
 | `BlinkCmpGitKindIcon<kind_name>`  | For `PR`                |
 | `BlinkCmpGitLabel<kind_name>Id`   | For `#1`                |
 | `BlinkCmpGitLabel<kind_name>Rest` | For `Add a new feature` |
-
 
 > [!NOTE]
 > The `Id` part is got by seperating the label by whitespaces, if you customize the `get_label`,
@@ -515,7 +513,7 @@ request domain.
 By default, `blink-cmp-git` will request those endpoints below:
 
 | Feature                            | API Endpoint                         |
-|------------------------------------|--------------------------------------|
+| ---------------------------------- | ------------------------------------ |
 | `github.issue`                     | `repos/OWNER/REPO/issues`            |
 | `github.pull_request`              | `repos/OWNER/REPO/pulls`             |
 | `github.mention`                   | `repos/OWNER/REPO/contributors`      |
@@ -601,11 +599,11 @@ it will be cached when you hover on one item.
 
 The release versions are something like `major.minor.patch`. When one of these numbers is increased:
 
-* `patch`: bugs are fixed or docs are added. This will not break the compatibility.
-* `minor`: compatible features are added. This may cause some configurations `deprecated`, but
-not break the compatibility.
-* `major`: incompatible features are added. All the `deprecated` configurations will be removed.
-This will break the compatibility.
+- `patch`: bugs are fixed or docs are added. This will not break the compatibility.
+- `minor`: compatible features are added. This may cause some configurations `deprecated`, but
+  not break the compatibility.
+- `major`: incompatible features are added. All the `deprecated` configurations will be removed.
+  This will break the compatibility.
 
 ## Acknowledgment
 

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ pre-cache when you enter insert mode or other mode you can input
 
 ## Reload Cache
 
-There are many cases will make the cache out of date. For example,
-if your `cwd` is in a repository, later you switch your `cwd` to another repository, the cache
-will use the first repository's result. To solve this problem, there is a command to
-reload the cache: `BlinkCmpGitReloadCache`. This command will clear all the cache and if
-`use_items_pre_cache` is enabled (default to `true`), it will pre-cache again.
+There are many cases that will make the cache invalid. For example, if your
+`cwd` is in a repository, later you switch your `cwd` to another repository,
+the cache will use the first repository's result. To solve this problem, there
+is a command to reload the cache: `BlinkCmpGitReloadCache`. This command will
+clear the cache.
 
 `blink-cmp-git` will create a auto command which uses `should_reload_cache` to determine
 whether or not to reload cache when entering insert mode.
@@ -587,13 +587,13 @@ end
 
 ## Performance
 
-Once `async` is enabled, the completion will has no effect to your other operations.
-How long it will take to show results depends on the network speed and the response time
-of the git center. But, don't worries, once you enable `use_items_cache`, the items will be
-cached when you first trigger the completion by inputting `@`, `#`, or `:`
-(You can DIY the triggers). Furthermore, once you enable `use_items_pre_cache`, when the
-source is created, it will pre-cache all the items. For the documentation of `mention` feature,
-it will be cached when you hover on one item.
+`blink-cmp-git` is async. This means that completion won't block other
+operations. How long it will take to show results depends on the network speed
+and the response time of the git center. But, don't worry, the items will be
+cached when you first trigger the completion by inputting `@`, `#`, or `:` (You
+can DIY the triggers). Furthermore, when the source is created, it will
+pre-cache all the items. For the documentation of the `mention` feature, it
+will be cached when you hover on one item.
 
 ## Version Introduction
 

--- a/lua/blink-cmp-git/default/github.lua
+++ b/lua/blink-cmp-git/default/github.lua
@@ -1,6 +1,7 @@
 local utils = require('blink-cmp-git.utils')
 local common = require('blink-cmp-git.default.common')
 
+--- @async
 local function default_github_enable()
     if
         not utils.command_found('git')

--- a/lua/blink-cmp-git/default/init.lua
+++ b/lua/blink-cmp-git/default/init.lua
@@ -2,24 +2,27 @@ local utils = require('blink-cmp-git.utils')
 local log = require('blink-cmp-git.log')
 log.setup({ title = 'blink-cmp-git' })
 
-local last_git_repo
+local last_git_repo ---@type string?
+
+--- @async
 local function default_should_reload_cache()
-    coroutine.wrap(function()
-        -- Do not reload cache when the buffer is a prompt buffer
-        -- or the source provider is disabled
-        if vim.bo.buftype == 'prompt' or not utils.source_provider_enabled() then return false end
-        if last_git_repo == nil then
-            last_git_repo = utils.get_git_repo_absolute_path()
-            if not last_git_repo then last_git_repo = '' end
-            return false
-        end
-        local new_git_repo = utils.get_git_repo_absolute_path() or last_git_repo
-        if new_git_repo ~= last_git_repo then
-            last_git_repo = new_git_repo
-            return true
-        end
+    local co = coroutine.running()
+    assert(co, 'This function should run inside a coroutine')
+
+    -- Do not reload cache when the buffer is a prompt buffer
+    -- or the source provider is disabled
+    if vim.bo.buftype == 'prompt' or not utils.source_provider_enabled() then return false end
+    if last_git_repo == nil then
+        last_git_repo = utils.get_git_repo_absolute_path()
+        if not last_git_repo then last_git_repo = '' end
         return false
-    end)()
+    end
+    local new_git_repo = utils.get_git_repo_absolute_path() or last_git_repo
+    if new_git_repo ~= last_git_repo then
+        last_git_repo = new_git_repo
+        return true
+    end
+    return false
 end
 
 local function default_before_reload_cache() log.info('Start reloading blink-cmp-git cache.') end

--- a/lua/blink-cmp-git/default/init.lua
+++ b/lua/blink-cmp-git/default/init.lua
@@ -4,20 +4,22 @@ log.setup({ title = 'blink-cmp-git' })
 
 local last_git_repo
 local function default_should_reload_cache()
-    -- Do not reload cache when the buffer is a prompt buffer
-    -- or the source provider is disabled
-    if vim.bo.buftype == 'prompt' or not utils.source_provider_enabled() then return false end
-    if last_git_repo == nil then
-        last_git_repo = utils.get_git_repo_absolute_path()
-        if not last_git_repo then last_git_repo = '' end
+    coroutine.wrap(function()
+        -- Do not reload cache when the buffer is a prompt buffer
+        -- or the source provider is disabled
+        if vim.bo.buftype == 'prompt' or not utils.source_provider_enabled() then return false end
+        if last_git_repo == nil then
+            last_git_repo = utils.get_git_repo_absolute_path()
+            if not last_git_repo then last_git_repo = '' end
+            return false
+        end
+        local new_git_repo = utils.get_git_repo_absolute_path() or last_git_repo
+        if new_git_repo ~= last_git_repo then
+            last_git_repo = new_git_repo
+            return true
+        end
         return false
-    end
-    local new_git_repo = utils.get_git_repo_absolute_path() or last_git_repo
-    if new_git_repo ~= last_git_repo then
-        last_git_repo = new_git_repo
-        return true
-    end
-    return false
+    end)()
 end
 
 local function default_before_reload_cache() log.info('Start reloading blink-cmp-git cache.') end

--- a/lua/blink-cmp-git/default/init.lua
+++ b/lua/blink-cmp-git/default/init.lua
@@ -68,10 +68,6 @@ end
 
 --- @type blink-cmp-git.Options
 return {
-    async = true,
-    use_items_cache = true,
-    -- Whether or not cache the triggers when the source is loaded
-    use_items_pre_cache = true,
     should_reload_cache = default_should_reload_cache,
     before_reload_cache = default_before_reload_cache,
     kind_icons = {

--- a/lua/blink-cmp-git/init.lua
+++ b/lua/blink-cmp-git/init.lua
@@ -133,8 +133,8 @@ function GitSource:create_pre_cache_jobs()
         coroutine.yield()
     end
 
-    for trigger, job_and_items in pairs(all_items) do
-        for _, item in pairs(job_and_items.items) do
+    for trigger, items in pairs(all_items) do
+        for _, item in pairs(items.items) do
             self.cache:set({ trigger, item.label }, item)
         end
     end

--- a/lua/blink-cmp-git/init.lua
+++ b/lua/blink-cmp-git/init.lua
@@ -107,6 +107,7 @@ end
 --- @async
 function GitSource:create_pre_cache_jobs()
     local co = coroutine.running()
+    assert(co, 'This function should run inside a coroutine')
 
     local all_items = {} ---@type table<string, {items: table}>
     local n_coroutines = 0

--- a/lua/blink-cmp-git/init.lua
+++ b/lua/blink-cmp-git/init.lua
@@ -255,6 +255,7 @@ function GitSource.new(opts, config)
 
         vim.iter(self.running_pre_cache_jobs):each(function(job) job:kill('TERM') end)
         self.running_pre_cache_jobs = {}
+        self._after_cache = nil
         coroutine.wrap(function() self:create_pre_cache_jobs() end)()
     end, { nargs = 0 })
     vim.api.nvim_create_augroup(blink_cmp_git_autocmd_group, { clear = true })

--- a/lua/blink-cmp-git/init.lua
+++ b/lua/blink-cmp-git/init.lua
@@ -12,7 +12,7 @@ log.setup({ title = 'blink-cmp-git' })
 --- @field git_source_config blink-cmp-git.Options
 --- @field cache blink-cmp-git.Cache
 --- @field running_pre_cache_jobs vim.SystemObj[]
---- @field _after_cache fun()
+--- @field _after_cache? fun()
 local GitSource = {}
 
 --- @param context blink.cmp.Context
@@ -313,6 +313,7 @@ function GitSource:get_completions(context, callback)
         local items = self.cache:get(trigger) ---@type table<string, lsp.CompletionItem>
         if not items then
             self._after_cache = function()
+                self._after_cache = nil
                 local ok, err = coroutine.resume(co)
                 if not ok then vim.notify(debug.traceback(co, err), vim.log.levels.ERROR) end
             end

--- a/lua/blink-cmp-git/types.lua
+++ b/lua/blink-cmp-git/types.lua
@@ -35,10 +35,7 @@
 --- @alias blink-cmp-git.GCSGitCenterKeys 'github'|'gitlab'|string
 
 -- TODO:
--- remove use_items_cache
 --- @class (exact) blink-cmp-git.Options
---- @field use_items_cache? boolean|fun(): boolean
---- @field use_items_pre_cache? boolean|fun(): boolean
 --- @field should_reload_cache? fun(): boolean
 --- @field before_reload_cache? fun()
 --- @field kind_icons? table<string, string>

--- a/lua/blink-cmp-git/types.lua
+++ b/lua/blink-cmp-git/types.lua
@@ -34,7 +34,6 @@
 
 --- @alias blink-cmp-git.GCSGitCenterKeys 'github'|'gitlab'|string
 
--- TODO:
 --- @class (exact) blink-cmp-git.Options
 --- @field should_reload_cache? fun(): boolean
 --- @field before_reload_cache? fun()

--- a/lua/blink-cmp-git/types.lua
+++ b/lua/blink-cmp-git/types.lua
@@ -19,7 +19,7 @@
 --- @field get_command? string|fun(): string
 --- @field get_command_args? string[]|fun(command:string, token: string): string[]
 --- @field insert_text_trailing? string|fun(): string
---- @field separate_output? fun(output: string): any[]
+--- @field separate_output? fun(output: string): [integer, any]
 --- @field get_label? fun(item: any): string
 --- @field get_kind_name? fun(item: any): string
 --- @field get_insert_text? fun(item: any): string
@@ -35,9 +35,8 @@
 --- @alias blink-cmp-git.GCSGitCenterKeys 'github'|'gitlab'|string
 
 -- TODO:
--- remove async and use_items_cache
+--  use_items_cache
 --- @class (exact) blink-cmp-git.Options
---- @field async? boolean|fun(): boolean
 --- @field use_items_cache? boolean|fun(): boolean
 --- @field use_items_pre_cache? boolean|fun(): boolean
 --- @field should_reload_cache? fun(): boolean

--- a/lua/blink-cmp-git/types.lua
+++ b/lua/blink-cmp-git/types.lua
@@ -35,7 +35,7 @@
 --- @alias blink-cmp-git.GCSGitCenterKeys 'github'|'gitlab'|string
 
 -- TODO:
---  use_items_cache
+-- remove use_items_cache
 --- @class (exact) blink-cmp-git.Options
 --- @field use_items_cache? boolean|fun(): boolean
 --- @field use_items_pre_cache? boolean|fun(): boolean

--- a/lua/blink-cmp-git/utils.lua
+++ b/lua/blink-cmp-git/utils.lua
@@ -20,9 +20,6 @@ function M.is_inside_git_repo()
     )
     local out = coroutine.yield() --[[@as vim.SystemCompleted]]
 
-    vim.schedule(function() coroutine.resume(co) end)
-    coroutine.yield()
-
     return out.code == 0
 end
 
@@ -131,9 +128,6 @@ function M.get_repo_remote_url(remote_name)
 
     remote_name = remote_name or M.get_remote_name()
     if not M.command_found('git') then return '' end
-
-    vim.schedule(function() coroutine.resume(co) end)
-    coroutine.yield()
 
     vim.system(
         { 'git', 'remote', 'get-url', remote_name },

--- a/lua/blink-cmp-git/utils.lua
+++ b/lua/blink-cmp-git/utils.lua
@@ -1,18 +1,29 @@
 local M = {}
-local Job = require('plenary.job')
 
+--- @async
 function M.is_inside_git_repo()
+    local co = coroutine.running()
+    assert(co, 'This function should run inside a coroutine')
+
     if not M.command_found('git') then return false end
-    local res = false
-    ---@diagnostic disable-next-line: missing-fields
-    Job:new({
-        command = 'git',
-        args = { 'rev-parse', '--is-inside-work-tree' },
-        cwd = M.get_cwd(),
-        env = M.get_job_default_env(),
-        on_exit = function(_, return_value, _) res = return_value == 0 end,
-    }):sync()
-    return res
+    vim.system(
+        { 'git', 'rev-parse', '--is-inside-work-tree' },
+        {
+            text = true,
+            cwd = M.get_cwd(),
+            env = M.get_job_default_env(),
+        },
+        vim.schedule_wrap(function(out)
+            local ok, err = coroutine.resume(co, out)
+            if not ok then vim.notify(debug.traceback(co, err), vim.log.levels.ERROR) end
+        end)
+    )
+    local out = coroutine.yield() --[[@as vim.SystemCompleted]]
+
+    vim.schedule(function() coroutine.resume(co) end)
+    coroutine.yield()
+
+    return out.code == 0
 end
 
 function M.get_option(opt, ...)
@@ -112,20 +123,33 @@ function M.get_remote_name()
     return require('blink-cmp-git').get_latest_git_source_config().get_remote_name()
 end
 
+--- @param remote_name? string
+--- @async
 function M.get_repo_remote_url(remote_name)
+    local co = coroutine.running()
+    assert(co, 'This function should run inside a coroutine')
+
     remote_name = remote_name or M.get_remote_name()
     if not M.command_found('git') then return '' end
-    local output = ''
-    ---@diagnostic disable-next-line: missing-fields
-    Job:new({
-        command = 'git',
-        args = { 'remote', 'get-url', remote_name },
-        cwd = M.get_cwd(),
-        on_exit = function(job, return_value, _)
-            if return_value ~= 0 then return end
-            output = table.concat(job:result(), '\n')
-        end,
-    }):sync()
+
+    vim.schedule(function() coroutine.resume(co) end)
+    coroutine.yield()
+
+    vim.system(
+        { 'git', 'remote', 'get-url', remote_name },
+        {
+            text = true,
+            cwd = M.get_cwd(),
+        },
+        vim.schedule_wrap(function(out)
+            local ok, err = coroutine.resume(co, out)
+            if not ok then vim.notify(debug.traceback(co, err), vim.log.levels.ERROR) end
+        end)
+    )
+    local out = coroutine.yield() --[[@as vim.SystemCompleted]]
+
+    local output = out.code == 0 and out.stdout or ''
+    output = output:gsub('\n', '')
     return output
 end
 
@@ -138,23 +162,28 @@ end
 --- Get the absolute path of current git repo
 --- Return nil if not in a git repo
 --- @return string?
+--- @async
 function M.get_git_repo_absolute_path()
+    local co = coroutine.running()
+    assert(co, 'This function should run inside a coroutine')
+
     if vim.bo.filetype == 'octo' then return vim.fn.expand('%:p:h'):match('^octo://[^/]+/[^/]+') end
     if not M.command_found('git') then return nil end
-    local result
-    ---@diagnostic disable-next-line: missing-fields
-    Job:new({
-        command = 'git',
-        args = { 'rev-parse', '--show-toplevel' },
-        cwd = M.get_cwd(),
-        env = M.get_job_default_env(),
-        on_exit = function(j, return_value, _)
-            if return_value == 0 then
-                result = table.concat(j:result(), '\n')
-                if not M.truthy(result) then result = nil end
-            end
-        end,
-    }):sync()
+
+    vim.system(
+        { 'git', 'rev-parse', '--show-toplevel' },
+        {
+            text = true,
+            cwd = M.get_cwd(),
+            env = M.get_job_default_env(),
+        },
+        vim.schedule_wrap(function(out)
+            local ok, err = coroutine.resume(co, out)
+            if not ok then vim.notify(debug.traceback(co, err), vim.log.levels.ERROR) end
+        end)
+    )
+    local out = coroutine.yield() --[[@as vim.SystemCompleted]]
+    local result = out.stdout ~= '' and out.stdout or nil
     return result
 end
 


### PR DESCRIPTION
Problem:

The plugin isn't truly async everywhere. There are calls for `sync` on a plenary job that call `vim.wait` under the hood, which blocks the editor until the jobs has finished it's execution. This may not be a problem in unix-like systems, but it is in Windows.

This, plus the fact that the plugin delays the execution of this jobs until `InsertEnter` results in Neovim being blocked for a couple of seconds on `InsertEnter` the first time after opening Neovim.

Solution:

Ditch the plenary.nvim dependency altogether and use the builtin `vim.system` and lua coroutines to have async code everywhere.

As a consequence of this change I also ended up removing the `async` config option and defaulting to using async always (since there is no cost to doing so).

I would also prefer to eagerly start the cache related jobs earlier, but didn't change the code to do so because that's not my decision to make. Since they are async, they won't block the user in any case. This will allow the plugin to always offer completions results on insert mode, even when defaulting to async always.