### PR TITLE
fix: support manual trigger in should_show_items

### DIFF
--- a/lua/blink-cmp-git/init.lua
+++ b/lua/blink-cmp-git/init.lua
@@ -356,9 +356,18 @@ end
 
 --- @param context blink.cmp.Context
 function GitSource:should_show_items(context, _)
-    return context.trigger.initial_kind == 'trigger_character'
-        and context.mode ~= 'cmdline'
-        and vim.tbl_contains(self:get_trigger_characters(), context.trigger.initial_character)
+    if context.mode == 'cmdline' then return false end
+    if context.trigger.initial_kind == 'trigger_character' then
+        return vim.tbl_contains(self:get_trigger_characters(), context.trigger.initial_character)
+    end
+    local triggers = self:get_trigger_characters()
+    local line = context.line:sub(1, context.cursor[2])
+    for i = #line, 1, -1 do
+        local c = line:sub(i, i)
+        if vim.tbl_contains(triggers, c) then return true end
+        if c:match('%s') then return false end
+    end
+    return false
 end
 
 function GitSource:resolve(item, callback)


### PR DESCRIPTION
## Problem

My blink.cmp's completion menu has `auto_show = false` and git completions are unreachable. Typing a trigger character (`#`, `@`, `:`) fetches items from the source (i see "loading...") but the menu never opens because `auto_show` blocks it.

## Solution

When the trigger kind is not `trigger_character`, scan backward from the
cursor for a registered trigger character. This resolves my issue and ought to work in general (I tested with `auto_show=true` too, but please verify yourself). If one is found before any whitespace, show items.

Basically now the source should work regardless of how the menu was opened & doesn't change behavior for the existing `trigger_character` path.