### PR TITLE
fix: handle ssh:// scheme and other remote URL forms

### DIFF
--- a/lua/blink-cmp-git/utils.lua
+++ b/lua/blink-cmp-git/utils.lua
@@ -64,9 +64,15 @@ function M.get_repo_owner_and_repo(do_url_encode)
     res = M.get_repo_owner_and_repo_from_octo()
     if not M.truthy(res) then
         local remote_url = M.get_repo_remote_url()
-        -- remove the trailing .git, and remove the leading git@, https:// or http://
-        remote_url =
-            remote_url:gsub('%.git$', ''):gsub('^git@', ''):gsub('^https?://', ''):gsub('/$', '')
+        -- Strip the optional `.git` suffix, any URL scheme (`ssh://`, `git://`,
+        -- `https://`, ...), any `user[:password]@` prefix, an optional `:port`
+        -- segment between host and path, and the trailing slash.
+        remote_url = remote_url
+            :gsub('%.git$', '')
+            :gsub('^[a-z]+://', '')
+            :gsub('^[^/@]+@', '')
+            :gsub('^([^/]-):%d+/', '%1/')
+            :gsub('/$', '')
         owner, repo = remote_url:match('[/:](.+)/([^/]+)$')
         if not owner or not repo then
             -- This will never happen for default configuration


### PR DESCRIPTION
The current cleanup in `get_repo_owner_and_repo` only strips `git@` and
`https?://` prefixes, so several valid Git remote URL forms are parsed
incorrectly and the resulting `owner/repo` is bogus. The downstream effect is
that all GitHub features (issue / pull\_request / mention) hit `gh api` with a
malformed path and fail with `404 Not Found`.

The most common case I ran into is `ssh://` URLs, which `git clone ssh://...`
or `git remote add origin ssh://...` produce:

```lua
local url = 'ssh://git@github.com/owner/repo'
url = url:gsub('%.git$', ''):gsub('^git@', ''):gsub('^https?://', ''):gsub('/$', '')
-- url is unchanged because none of the gsubs match
local owner, repo = url:match('[/:](.+)/([^/]+)$')
-- owner == '//git@github.com/owner'   <-- broken
-- repo  == 'repo'
```

This is hit hard on GitHub Enterprise installations where SSH URLs are the
default form (e.g. `ssh://git@ghe.example.com/owner/repo`), but it is also
reproducible against `github.com` if you happen to use the URL form of SSH.

This PR generalizes the cleanup so the parser handles all forms that can be
used to reach GitHub or GitLab, while preserving the behavior that already
worked (most importantly, GitLab nested subgroups):

| URL form                                          | Before | After |
|---------------------------------------------------|:------:|:-----:|
| `https://host/o/r.git`                            | ✓      | ✓     |
| `git@host:o/r.git` (SCP-like SSH)                 | ✓      | ✓     |
| `https://gitlab.com/group/subgroup/project`       | ✓      | ✓     |
| `git@gitlab.com:group/subgroup/project.git`       | ✓      | ✓     |
| `ssh://git@gitlab.com/group/sub1/sub2/project`    | ✗      | ✓     |
| `ssh://git@host/o/r`                              | ✗      | ✓     |
| `ssh://git@host:22/o/r` (with port)               | ✗      | ✓     |
| `ssh://user@host/o/r` (non-`git` user)            | ✗      | ✓     |
| `https://user@host/o/r`                           | ✗      | ✓     |
| `https://user:token@host/o/r`                     | ✗      | ✓     |
| `git://host/o/r`                                  | ✗      | ✓     |

Changes to the cleanup pipeline:

1. `^git@` → `^[^/@]+@` — strip any `user@` (or `user:password@`) prefix, not
   just `git@`.
2. `^https?://` → `^[a-z]+://` — strip any URL scheme so `ssh://`, `git://`,
   etc. all work.
3. New `^([^/]-):%d+/` → `%1/` — strip an optional `:port` segment between
   host and path, so URLs like `ssh://git@host:22/o/r` parse correctly. Done
   as a separate gsub so the existing `(.+)` owner capture is left alone and
   GitLab nested subgroups continue to work.

I verified all rows in the table above with a small Lua script and they all
yield the expected `owner/repo` (or `group/.../project` for subgroups).